### PR TITLE
Fix developer name for ru localization

### DIFF
--- a/ru/apps/apps.json
+++ b/ru/apps/apps.json
@@ -43,7 +43,7 @@
         ]
      },
       {
-        "developer_name" : "Oleg Brailean",
+        "developer_name" : "Олег Брайлян",
         "github_username" : "baksogen",
         "apps" : [
             {


### PR DESCRIPTION
Имя разработчика для русской локализации поправил.
Все приложения имеют одинаковые англоязычные наименования для всех локалей.